### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.0 to 4.0.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,10 +26,10 @@ version.io.github.classgraph..classgraph=4.8.65
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.0
+version.io.kotest..kotest-assertions-core-jvm=4.0.1
 
 version.io.kotest..kotest-runner-junit5-jvm=+
-##                              # available=4.0.0
+##                              # available=4.0.1
 
 version.kotlin=1.3.70
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.