### PR TITLE
Upgrade arrow-core from 0.10.4 to 0.10.5

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -22,7 +22,7 @@ version.ch.qos.logback..logback-classic=1.3.0-alpha5
 
 version.com.uchuhimo..konf=0.22.1
 
-version.io.arrow-kt..arrow-core=0.10.4
+version.io.arrow-kt..arrow-core=0.10.5
 
 version.io.github.classgraph..classgraph=4.8.65
 ##                           # available=4.8.67
@@ -32,11 +32,9 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.0
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.1
 
-version.io.kotest..kotest-runner-junit5-jvm=4.0.1
+version.io.kotest..kotest-runner-junit5=4.0.1
 
 version.kotlin=1.3.71
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=2.1.5
 ##                                                 # available=3.4.0.201406110918-r
-
-version.io.kotest..kotest-runner-junit5=4.0.1


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.