### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.1 to 4.0.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -9,6 +9,7 @@ plugin.com.github.breadmoirai.github-release=2.2.12
 plugin.com.github.johnrengelman.shadow=5.2.0
 
 plugin.io.gitlab.arturbosch.detekt=1.7.3
+##                     # available=1.7.4
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
@@ -28,11 +29,12 @@ version.io.github.classgraph..classgraph=4.8.65
 ##                           # available=4.8.67
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.0
-##                                         # available=1.7.3
+##                                         # available=1.7.4
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.1
+version.io.kotest..kotest-assertions-core-jvm=4.0.2
 
 version.io.kotest..kotest-runner-junit5=4.0.1
+##                          # available=4.0.2
 
 version.kotlin=1.3.71
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.