### PR TITLE
Upgrade kotest-runner-junit5 from 4.0.2 to 4.0.3

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,8 +29,9 @@ version.io.github.classgraph..classgraph=4.8.69
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.4
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.2
+##                                # available=4.0.3
 
-version.io.kotest..kotest-runner-junit5=4.0.2
+version.io.kotest..kotest-runner-junit5=4.0.3
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.