### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.3 to 4.0.4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,13 +26,15 @@ version.com.uchuhimo..konf=0.22.1
 version.io.arrow-kt..arrow-core=0.10.5
 
 version.io.github.classgraph..classgraph=4.8.73
+##                           # available=4.8.75
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.7.4
 ##                                         # available=1.8.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.3
+version.io.kotest..kotest-assertions-core-jvm=4.0.4
 
 version.io.kotest..kotest-runner-junit5=4.0.3
+##                          # available=4.0.4
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.