### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.4 to 4.0.5

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -28,9 +28,10 @@ version.io.github.classgraph..classgraph=4.8.75
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.8.0
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.4
+version.io.kotest..kotest-assertions-core-jvm=4.0.5
 
 version.io.kotest..kotest-runner-junit5=4.0.4
+##                          # available=4.0.5
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.