### PR TITLE
Upgrade io.gitlab.arturbosch.detekt from 1.8.0 to 1.9.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@ plugin.com.github.breadmoirai.github-release=2.2.12
 
 plugin.com.github.johnrengelman.shadow=5.2.0
 
-plugin.io.gitlab.arturbosch.detekt=1.8.0
+plugin.io.gitlab.arturbosch.detekt=1.9.0
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
@@ -27,6 +27,7 @@ version.io.arrow-kt..arrow-core=0.10.5
 version.io.github.classgraph..classgraph=4.8.78
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.8.0
+##                                         # available=1.9.0
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.