### PR TITLE
Make commit author configurable

### DIFF
--- a/src/main/kotlin/org/danilopianini/upgradle/Git.kt
+++ b/src/main/kotlin/org/danilopianini/upgradle/Git.kt
@@ -6,6 +6,7 @@ import org.danilopianini.upgradle.api.Credentials.Companion.authenticated
 import org.danilopianini.upgradle.api.OnFile
 import org.danilopianini.upgradle.api.Operation
 import org.danilopianini.upgradle.api.Pattern
+import org.danilopianini.upgradle.config.CommitAuthor
 import org.eclipse.egit.github.core.Label
 import org.eclipse.egit.github.core.PullRequest
 import org.eclipse.egit.github.core.PullRequestMarker
@@ -39,8 +40,8 @@ fun Git.add(location: File, changes: Iterable<Change>) = add().apply {
         }
     }.call()
 
-fun Git.commit(message: String, author: String = "UpGradle [Bot]", email: String = "danilo.pianini@gmail.com") =
-    commit().setMessage(message).setAuthor(PersonIdent(author, email)).call()
+fun Git.commit(message: String, author: CommitAuthor) =
+    commit().setMessage(message).setAuthor(PersonIdent(author.name, author.email)).call()
 
 fun Git.pushTo(branch: String, credentials: Credentials): List<RemoteRefUpdate> = push()
     .authenticated(credentials)

--- a/src/main/kotlin/org/danilopianini/upgradle/UpGradle.kt
+++ b/src/main/kotlin/org/danilopianini/upgradle/UpGradle.kt
@@ -45,7 +45,7 @@ class UpGradle(configuration: Config.() -> Config = { from.yaml.resource("upgrad
                     logger.info("Changes: {}", changes)
                     git.add(destination, changes)
                     // Commit changes
-                    git.commit(update.commitMessage)
+                    git.commit(update.commitMessage, configuration.author)
                     // Push the new branch
                     logger.info("Pushing ${update.branch}...")
                     val pushResults = git.pushTo(update.branch, credentials)

--- a/src/main/kotlin/org/danilopianini/upgradle/config/Configurator.kt
+++ b/src/main/kotlin/org/danilopianini/upgradle/config/Configurator.kt
@@ -79,11 +79,14 @@ class ColoredLabel : Label() {
     }
 }
 
+data class CommitAuthor(val name: String = "UpGradle [Bot]", val email: String = "<>")
+
 data class Configuration(
     val includes: List<RepoDescriptor>,
     val excludes: List<RepoDescriptor>?,
     val modules: List<String>,
-    val labels: List<ColoredLabel> = emptyList()
+    val labels: List<ColoredLabel> = emptyList(),
+    val author: CommitAuthor = CommitAuthor()
 ) {
 
     fun selectedRemoteBranchesFor(service: RepositoryService): Set<SelectedRemoteBranch> =

--- a/src/test/kotlin/TestAuthorConfig.kt
+++ b/src/test/kotlin/TestAuthorConfig.kt
@@ -1,0 +1,41 @@
+import com.uchuhimo.konf.source.yaml
+import io.kotest.assertions.inspecting
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import org.danilopianini.upgradle.config.Configuration
+import org.danilopianini.upgradle.config.Configurator
+
+class TestAuthorConfig : FreeSpec({
+    "A loaded configuration" - {
+        fun configOf(s: String): Configuration = Configurator.load { from.yaml.string(s) }
+        val baseConfig = """
+            includes:
+              - owners: .*
+                repos: .*
+                branches:
+                  - master
+            modules:
+              - GradleWrapper
+              - RefreshVersions
+        """.trimIndent()
+
+        "should use given author" {
+            val authorNode = """
+                author:
+                  name: Test McTestface
+                  email: test@example.com
+            """.trimIndent()
+
+            inspecting(configOf("$baseConfig\n$authorNode").author) {
+                name shouldBe "Test McTestface"
+                email shouldBe "test@example.com"
+            }
+        }
+        "should use default if none given" {
+            inspecting(configOf(baseConfig).author) {
+                name shouldBe "UpGradle [Bot]"
+                email shouldBe "<>"
+            }
+        }
+    }
+})


### PR DESCRIPTION
Fixes #61

Hey there!
Since the linked issue was stale for a while, I decided to pick it up. The default value for the email is what git recognizes as an 'empty' email.
Alternatively, I think not having a default would be better for this configuration, but that would require existing configs to update.