### PR TITLE
Document usage of the 'author' config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The structure is quite simple, and expects the following keys:
 * `includes`: which repositories should be considered
 * (optional) `excludes`: matching repositories will not be considered. The selection is operated over those selected by `includes`
 * `modules`: the list of modules to execute
-* *optional* `labels`: the list of labels to apply to the pull requests
+* (optional) `labels`: the list of labels to apply to the pull requests
+* (optional) `author`: Specifies the author to be used for commit messages
 
 ### Inclusion and exclusion of repositories
 
@@ -121,6 +122,15 @@ The content of `labels` is a single or multiple descriptor expecting:
 
 In case the desired label is not available in the repository for which the PR is being prepared,
 a new label with the desired name and color will be added.
+
+### Specifying the commit author
+
+`author` is used to determine which name and email address is to be associated for the generated commits and directly relate to git config. It's advised to at least use a real email address.
+
+* `name` - Relates to `git config user.name`, defaults to `UpGradle [Bot]`
+* `email` - Relates to `git config user.email`, defaults to `<>`
+
+N.B. The author of the pull-request only depends on the owner of the `GITHUB_TOKEN`
 
 ### Working example
 


### PR DESCRIPTION
Hi again, had a chance to test it now. Works as expected 🎉 

Is the documentation specific enough?

| No Config | Config |
| - | - |
| <img width="475" alt="No Config" src="https://user-images.githubusercontent.com/6658557/82578246-70e4f000-9b8c-11ea-857a-52ed5252f82c.png"> | <img width="316" alt="image" src="https://user-images.githubusercontent.com/6658557/82578366-92de7280-9b8c-11ea-888c-daf190f1e739.png"> |

