### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.5 to 4.0.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -28,7 +28,7 @@ version.io.github.classgraph..classgraph=4.8.80
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.5
+version.io.kotest..kotest-assertions-core-jvm=4.0.6
 
 version.io.kotest..kotest-runner-junit5=4.0.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.