### PR TITLE
Upgrade io.gitlab.arturbosch.detekt from 1.9.1 to 1.10.0-RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@ plugin.com.github.breadmoirai.github-release=2.2.12
 
 plugin.com.github.johnrengelman.shadow=5.2.0
 
-plugin.io.gitlab.arturbosch.detekt=1.9.1
+plugin.io.gitlab.arturbosch.detekt=1.10.0-RC1
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.