### PR TITLE
Upgrade detekt-formatting from 1.9.1 to 1.10.0-RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -26,7 +26,7 @@ version.io.arrow-kt..arrow-core=0.10.5
 
 version.io.github.classgraph..classgraph=4.8.86
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.10.0-RC1
 
 version.io.kotest..kotest-assertions-core-jvm=4.1.0.RC2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.