### PR TITLE
Upgrade kotest-assertions-core-jvm from 4.0.6 to 4.1.0.RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -28,7 +28,7 @@ version.io.github.classgraph..classgraph=4.8.86
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
 
-version.io.kotest..kotest-assertions-core-jvm=4.0.6
+version.io.kotest..kotest-assertions-core-jvm=4.1.0.RC2
 
 version.io.kotest..kotest-runner-junit5=4.1.0.RC2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.