### PR TITLE
Upgrade kotest-runner-junit5 from 4.0.6 to 4.1.0.RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -30,7 +30,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.9.1
 
 version.io.kotest..kotest-assertions-core-jvm=4.0.6
 
-version.io.kotest..kotest-runner-junit5=4.0.6
+version.io.kotest..kotest-runner-junit5=4.1.0.RC2
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.