### PR TITLE
Upgrade com.github.johnrengelman.shadow from 5.2.0 to 6.0.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -6,7 +6,7 @@
 
 plugin.com.github.breadmoirai.github-release=2.2.12
 
-plugin.com.github.johnrengelman.shadow=5.2.0
+plugin.com.github.johnrengelman.shadow=6.0.0
 
 plugin.io.gitlab.arturbosch.detekt=1.10.0-RC1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.