### PR TITLE
Upgrade kotest from 4.1.0.RC2 to 4.1.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -34,7 +34,7 @@ version.kittinunf.fuel=2.2.3
 
 version.kittinunf.result=3.0.1
 
-version.kotest=4.1.0.RC2
+version.kotest=4.1.0
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.