### PR TITLE
Upgrade kotlin from 1.3.72 to 1.4.0-rc

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -36,7 +36,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.10.0
 
 version.kotest=4.1.3
 
-version.kotlin=1.3.72
+version.kotlin=1.4.0-rc
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.8.0.202005061305-m2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.