### PR TITLE
Upgrade detekt-formatting from 1.10.0 to 1.11.0-RC1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -32,7 +32,7 @@ version.io.arrow-kt..arrow-core=0.10.5
 
 version.io.github.classgraph..classgraph=4.8.87
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.10.0
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.11.0-RC1
 
 version.kotest=4.1.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.