### PR TITLE
Upgrade detekt from 1.11.0-RC1 to 1.11.0-RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -8,7 +8,7 @@ plugin.com.github.breadmoirai.github-release=2.2.12
 
 plugin.com.github.johnrengelman.shadow=6.0.0
 
-plugin.io.gitlab.arturbosch.detekt=1.11.0-RC1
+plugin.io.gitlab.arturbosch.detekt=1.11.0-RC2
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.