### PR TITLE
Upgrade mockito-core from 3.4.6 to 3.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -40,4 +40,4 @@ version.kotlin=1.3.72
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.8.0.202005061305-m2
 
-version.org.mockito..mockito-core=3.4.6
+version.org.mockito..mockito-core=3.5.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.