### PR TITLE
Upgrade detekt-formatting from 1.12.0-RC1 to 1.12.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -32,7 +32,7 @@ version.io.arrow-kt..arrow-core=0.10.5
 
 version.io.github.classgraph..classgraph=4.8.89
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0-RC1
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
 version.kotest=4.2.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.