### PR TITLE
Upgrade kotest from 4.2.0 to 4.2.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -34,7 +34,7 @@ version.io.github.classgraph..classgraph=4.8.89
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0-RC1
 
-version.kotest=4.2.0
+version.kotest=4.2.2
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.