### PR TITLE
Upgrade mockito-core from 3.5.7 to 3.5.9

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -43,4 +43,4 @@ version.kotlin=1.4.0
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 
-version.org.mockito..mockito-core=3.5.7
+version.org.mockito..mockito-core=3.5.9


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.