### PR TITLE
Upgrade kotest from 4.2.3 to 4.2.4

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -37,7 +37,7 @@ version.io.github.classgraph..classgraph=4.8.89
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
-version.kotest=4.2.3
+version.kotest=4.2.4
 
 version.kotlin=1.4.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.