### PR TITLE
Upgrade commons-io from 2.7 to 2.8.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -29,7 +29,7 @@ version.com.github.kittinunf.result..result=3.1.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.commons-io..commons-io=2.7
+version.commons-io..commons-io=2.8.0
 
 version.io.arrow-kt..arrow-core=0.10.5
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.