### PR TITLE
Upgrade kotlin from 1.4.0 to 1.4.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -39,7 +39,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.12.0
 
 version.kotest=4.2.4
 
-version.kotlin=1.4.0
+version.kotlin=1.4.10
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.