### PR TITLE
Upgrade arrow-core from 0.10.5 to 0.11.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.commons-io..commons-io=2.7
 
-version.io.arrow-kt..arrow-core=0.10.5
+version.io.arrow-kt..arrow-core=0.11.0
 
 version.io.github.classgraph..classgraph=4.8.89
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.