### PR TITLE
Upgrade dokka from 1.4.0 to 1.4.10

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
 plugin.org.danilopianini.publish-on-central=0.3.0
 
-plugin.org.jetbrains.dokka=1.4.0
+plugin.org.jetbrains.dokka=1.4.10
 
 plugin.org.jlleitschuh.gradle.ktlint=9.3.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.