### PR TITLE
Upgrade kotest from 4.2.5 to 4.2.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -35,7 +35,7 @@ version.io.github.classgraph..classgraph=4.8.90
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.1
 
-version.kotest=4.2.5
+version.kotest=4.2.6
 
 version.kotlin=1.4.10
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.