### PR TITLE
Upgrade commons-io from 2.6 to 2.8.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -27,7 +27,7 @@ version.com.github.kittinunf.fuel=2.3.0
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.commons-io..commons-io=2.6
+version.commons-io..commons-io=2.8.0
 
 version.io.arrow-kt..arrow-core=0.11.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.