### PR TITLE
Upgrade mockito-core from 3.6.0 to 3.6.28

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -41,7 +41,7 @@ version.kotlin=1.4.10
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 
-version.org.mockito..mockito-core=3.6.0
+version.org.mockito..mockito-core=3.6.28
 
 version.com.charleskorn.kaml..kaml=0.26.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.