### PR TITLE
Upgrade kotest from 4.3.1 to 4.3.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -35,7 +35,7 @@ version.io.github.classgraph..classgraph=4.8.94
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
 
-version.kotest=4.3.1
+version.kotest=4.3.2
 
 version.kotlin=1.4.21
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.