### PR TITLE
Upgrade detekt-formatting from 1.14.2 to 1.15.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -33,7 +33,7 @@ version.io.arrow-kt..arrow-core=0.11.0
 
 version.io.github.classgraph..classgraph=4.8.95
 
-version.io.gitlab.arturbosch.detekt..detekt-formatting=1.14.2
+version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 
 version.kotest=4.3.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.