### PR TITLE
Upgrade classgraph from 4.8.95 to 4.8.97

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version.commons-io..commons-io=2.8.0
 
 version.io.arrow-kt..arrow-core=0.11.0
 
-version.io.github.classgraph..classgraph=4.8.95
+version.io.github.classgraph..classgraph=4.8.97
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.15.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.