### PR TITLE
Upgrade snakeyaml from 1.27 to 1.28

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -47,4 +47,4 @@ version.com.charleskorn.kaml..kaml=0.28.3
 
 version.kotlinx.serialization=1.0.0-RC
 
-version.org.yaml..snakeyaml=1.27
+version.org.yaml..snakeyaml=1.28


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.