### PR TITLE
Upgrade mockito-core from 3.7.7 to 3.8.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -41,7 +41,7 @@ version.kotlin=1.4.31
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 
-version.org.mockito..mockito-core=3.7.7
+version.org.mockito..mockito-core=3.8.0
 
 version.com.charleskorn.kaml..kaml=0.28.3
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.