### PR TITLE
Upgrade kotlin from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -39,7 +39,7 @@ version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
 version.kotest=4.5.0
 
-version.kotlin=1.4.32
+version.kotlin=1.5.0
 
 version.mockito=3.10.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.