### PR TITLE
Upgrade mockito-core from 3.9.0 to 3.10.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -43,6 +43,6 @@ version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.20200826080
 
 version.org.gradle..gradle-tooling-api=7.0.1
 
-version.org.mockito..mockito-core=3.9.0
+version.org.mockito..mockito-core=3.10.0
 
 version.org.yaml..snakeyaml=1.28


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.