### PR TITLE
Upgrade gradle-tooling-api from 7.0.1 to 7.0.2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -41,7 +41,7 @@ version.kotlin=1.4.32
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 
-version.org.gradle..gradle-tooling-api=7.0.1
+version.org.gradle..gradle-tooling-api=7.0.2
 
 version.org.mockito..mockito-core=3.10.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.