### PR TITLE
Upgrade kotest from 4.5.0 to 4.6.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -37,7 +37,7 @@ version.io.github.classgraph..classgraph=4.8.106
 
 version.io.gitlab.arturbosch.detekt..detekt-formatting=1.17.1
 
-version.kotest=4.5.0
+version.kotest=4.6.0
 
 version.kotlin=1.5.10
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.