### PR TITLE
Upgrade gradle-tooling-api from 7.0.2 to 7.1

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -45,7 +45,7 @@ version.mockito=3.11.1
 
 version.org.eclipse.mylyn.github..org.eclipse.egit.github.core=5.9.0.202008260805-m3
 
-version.org.gradle..gradle-tooling-api=7.0.2
+version.org.gradle..gradle-tooling-api=7.1
 
 version.org.jacoco..org.jacoco.core=0.8.7
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.