### PR TITLE
Upgrade dokka from 1.4.32 to 1.5.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -17,7 +17,7 @@ plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 
-plugin.org.jetbrains.dokka=1.4.32
+plugin.org.jetbrains.dokka=1.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.1.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.