### PR TITLE
Upgrade commons-io from 2.10.0 to 2.11.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -31,7 +31,7 @@ version.com.github.kittinunf.fuel=2.3.1
 
 version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
-version.commons-io..commons-io=2.10.0
+version.commons-io..commons-io=2.11.0
 
 version.io.github.classgraph..classgraph=4.8.110
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.