### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.3 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,10 +32,6 @@ repositories {
     }
 }
 
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 val additionalTools: Configuration by configurations.creating
 
 dependencies {

--- a/versions.properties
+++ b/versions.properties
@@ -13,7 +13,7 @@ plugin.com.github.johnrengelman.shadow=7.0.0
 
 plugin.io.gitlab.arturbosch.detekt=version.io.gitlab.arturbosch.detekt..detekt-formatting
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.3
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.publish-on-central=0.5.0
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.